### PR TITLE
Prevent solution data interfering with submission's

### DIFF
--- a/exec-wrap.js
+++ b/exec-wrap.js
@@ -45,7 +45,7 @@ for (var i = 0; i < modFiles.length; i++) {
     // include in submission? defaults to true
     if (isSubmission && mod.wrapSubmission === false) continue
     // include in solution? defaults to false
-    if (isSolution && mod.wrapSolution) continue
+    if (isSolution && !mod.wrapSolution) continue
     mods.unshift(mod)
 
     // give it the ctx if it exports a function

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "xtend": "~2.1.2"
+    "xtend": "~2.1.2",
+    "after": "~0.8.1"
   }
 }

--- a/wrappedexec.js
+++ b/wrappedexec.js
@@ -4,9 +4,12 @@ const execWrapPath = require.resolve('./exec-wrap')
     , fs           = require('fs')
     , assert       = require('assert')
     , xtend        = require('xtend')
+    , after        = require('after')
 
 function fix (exercise) {
   var dataPath = path.join(os.tmpDir(), '~workshopper.wraptmp.' + process.pid)
+  var submissionPath = dataPath + '-submission'
+  var solutionPath   = dataPath + '-solution'
 
   exercise.wrapData = {}
   exercise.wrapMods = []
@@ -15,33 +18,39 @@ function fix (exercise) {
 
     this.solutionArgs.unshift('$execwrap$solution') // flag if solution
     this.solutionArgs.unshift('$execwrap$' + this.solution) // original main cmd
-    this.solutionArgs.unshift('$execwrap$' + dataPath) // path to context data
+    this.solutionArgs.unshift('$execwrap$' + solutionPath) // path to context data
     this.solutionArgs.unshift('$execwrap$' + JSON.stringify(exercise.wrapMods)) // list of mods to load
     this.solution = execWrapPath
 
     this.submissionArgs.unshift('$execwrap$submission') // flag if submission
     this.submissionArgs.unshift('$execwrap$' + this.submission) // original main cmd
-    this.submissionArgs.unshift('$execwrap$' + dataPath) // path to context data
+    this.submissionArgs.unshift('$execwrap$' + submissionPath) // path to context data
     this.submissionArgs.unshift('$execwrap$' + JSON.stringify(exercise.wrapMods)) // list of mods to load
     this.submission = execWrapPath
 
-    fs.writeFile(dataPath, JSON.stringify(exercise.wrapData), 'utf8', function (err) {
+    var wrapData = JSON.stringify(exercise.wrapData)
+    var files = [ submissionPath , solutionPath ]
+    var done = after(files.length, function(err) {
       if (err)
         return callback(new Error('Error writing execwrap data: ' + (err.message || err), err))
 
       callback()
     })
+
+    files.forEach(function (path) {
+      fs.writeFile(path, wrapData, 'utf8', done)
+    })
   })
 
   exercise.addVerifyProcessor(function (callback) {
     // sync... yes.. unfortunately, otherwise we'll have timing problems
-    fs.readFile(dataPath, 'utf8', function (err, data) {
+    fs.readFile(submissionPath, 'utf8', function (err, data) {
       if (err)
         return callback(new Error('Error reading execwrap data: ' + (err.message || err), err))
 
       exercise.wrapData = JSON.parse(data)
 
-      fs.unlink(dataPath, function () {
+      fs.unlink(submissionPath, function () {
         callback(null, true) // pass, nothing to fail here
       })
     })


### PR DESCRIPTION
Both the solution and submission were being wrapped, and given the same `dataPath` to write their files to. This would generally result in `exercise.wrapData` coming from the solution instead of the submission, though sometimes the solution would finish early and it would run as expected.

Also corrected a check in exec-wrap.js to properly identify whether the solution should be wrapped.

Thanks! :)
