### PR TITLE
fix 7.5.0 deprecation warning

### DIFF
--- a/wrappedexec.js
+++ b/wrappedexec.js
@@ -6,6 +6,8 @@ const execWrapPath = require.resolve('./exec-wrap')
     , xtend        = require('xtend')
     , after        = require('after')
 
+os.tmpDir = os.tmpdir;
+
 function fix (exercise) {
   var dataPath = path.join(os.tmpDir(), '~workshopper.wraptmp.' + process.pid)
   var submissionPath = dataPath + '-submission'


### PR DESCRIPTION
simple fix to fix the deprecation warning for anyone using Node.js 7.5.0+. 